### PR TITLE
setup.py: Exit 1 for invalid arguments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ ops = ("install", "build", "sdist", "uninstall", "clean")
 
 if len (sys.argv) < 2 or sys.argv[1] not in ops:
     print("Please specify operation : %s" % " | ".join (ops))
-    raise SystemExit
+    raise SystemExit(1)
 
 prefix = None
 gtkver = "3.0"


### PR DESCRIPTION
When invalid command-line arguments are provided to setup.py, it will exit with exit status 1 now. Previously, it defaulted to exiting with 0 (indicating success).